### PR TITLE
[codex] Replace Cachix cache wiring with Attic

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,10 +27,18 @@ jobs:
         with:
           extra-conf: accept-flake-config = true
 
-      - uses: cachix/cachix-action@v16
-        with:
-          name: ${{ vars.CACHIX_CACHE }}
-          authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+      - name: Configure Nix caches
+        run: |
+          mkdir -p "$HOME/.config/nix"
+          cat > "$HOME/.config/nix/nix.conf" <<EOF
+          accept-flake-config = true
+          experimental-features = nix-command flakes
+          substituters = https://cache.nixos.org ${{ vars.SUBSTITUTERS }}
+          trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= ${{ vars.TRUSTED_PUBLIC_KEYS }}
+          netrc-file = $HOME/.config/nix/netrc
+          EOF
+          touch "$HOME/.config/nix/netrc"
+          chmod 0600 "$HOME/.config/nix/netrc"
 
       - name: Check formatting
         run: nix develop --impure .#pre-commit -c pre-commit run --all-files
@@ -50,10 +58,18 @@ jobs:
         with:
           extra-conf: accept-flake-config = true
 
-      - uses: cachix/cachix-action@v16
-        with:
-          name: ${{ vars.CACHIX_CACHE }}
-          authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+      - name: Configure Nix caches
+        run: |
+          mkdir -p "$HOME/.config/nix"
+          cat > "$HOME/.config/nix/nix.conf" <<EOF
+          accept-flake-config = true
+          experimental-features = nix-command flakes
+          substituters = https://cache.nixos.org ${{ vars.SUBSTITUTERS }}
+          trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= ${{ vars.TRUSTED_PUBLIC_KEYS }}
+          netrc-file = $HOME/.config/nix/netrc
+          EOF
+          touch "$HOME/.config/nix/netrc"
+          chmod 0600 "$HOME/.config/nix/netrc"
 
       - name: Build & activate the Nix Dev Shell
         run: |
@@ -82,10 +98,18 @@ jobs:
         with:
           extra-conf: accept-flake-config = true
 
-      - uses: cachix/cachix-action@v16
-        with:
-          name: ${{ vars.CACHIX_CACHE }}
-          authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+      - name: Configure Nix caches
+        run: |
+          mkdir -p "$HOME/.config/nix"
+          cat > "$HOME/.config/nix/nix.conf" <<EOF
+          accept-flake-config = true
+          experimental-features = nix-command flakes
+          substituters = https://cache.nixos.org ${{ vars.SUBSTITUTERS }}
+          trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= ${{ vars.TRUSTED_PUBLIC_KEYS }}
+          netrc-file = $HOME/.config/nix/netrc
+          EOF
+          touch "$HOME/.config/nix/netrc"
+          chmod 0600 "$HOME/.config/nix/netrc"
 
       - name: Build & activate the Nix Dev Shell
         run: |
@@ -114,7 +138,7 @@ jobs:
         include:
           - runner: [self-hosted, nixos, x86-64-v3]
             system: x86_64-linux
-          - runner: macos-latest-xlarge
+          - runner: [self-hosted, macOS, aarch64-darwin]
             system: aarch64-darwin
     runs-on: ${{ matrix.runner }}
 
@@ -127,10 +151,18 @@ jobs:
         with:
           extra-conf: accept-flake-config = true
 
-      - uses: cachix/cachix-action@v16
-        with:
-          name: ${{ vars.CACHIX_CACHE }}
-          authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+      - name: Configure Nix caches
+        run: |
+          mkdir -p "$HOME/.config/nix"
+          cat > "$HOME/.config/nix/nix.conf" <<EOF
+          accept-flake-config = true
+          experimental-features = nix-command flakes
+          substituters = https://cache.nixos.org ${{ vars.SUBSTITUTERS }}
+          trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= ${{ vars.TRUSTED_PUBLIC_KEYS }}
+          netrc-file = $HOME/.config/nix/netrc
+          EOF
+          touch "$HOME/.config/nix/netrc"
+          chmod 0600 "$HOME/.config/nix/netrc"
 
       - name: Install current Bash on macOS
         if: runner.os == 'macOS'
@@ -181,10 +213,18 @@ jobs:
         with:
           extra-conf: accept-flake-config = true
 
-      - uses: cachix/cachix-action@v16
-        with:
-          name: ${{ vars.CACHIX_CACHE }}
-          authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+      - name: Configure Nix caches
+        run: |
+          mkdir -p "$HOME/.config/nix"
+          cat > "$HOME/.config/nix/nix.conf" <<EOF
+          accept-flake-config = true
+          experimental-features = nix-command flakes
+          substituters = https://cache.nixos.org ${{ vars.SUBSTITUTERS }}
+          trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= ${{ vars.TRUSTED_PUBLIC_KEYS }}
+          netrc-file = $HOME/.config/nix/netrc
+          EOF
+          touch "$HOME/.config/nix/netrc"
+          chmod 0600 "$HOME/.config/nix/netrc"
 
       - name: Build & activate the Nix Dev Shell
         run: |

--- a/.github/workflows/update-flake-lock.yml
+++ b/.github/workflows/update-flake-lock.yml
@@ -13,7 +13,6 @@ jobs:
     uses: blocksense-network/nixos-modules/.github/workflows/reusable-update-flake-lock.yml@main
     secrets:
       NIX_GITHUB_TOKEN: ${{ secrets.BLOCKSENSE_GITHUB_ACCESS_TOKEN }}
-      CACHIX_AUTH_TOKEN: ${{ secrets.BLOCKSENSE_INFRA_CACHIX_AUTH_TOKEN }}
       CREATE_PR_APP_ID: ${{ secrets.NIX_FLAKE_UPDATE_PR_BOT_APP_ID }}
       CREATE_PR_APP_PRIVATE_KEY: ${{ secrets.NIX_FLAKE_UPDATE_PR_BOT_APP_PRIVATE_KEY }}
     with:

--- a/flake.nix
+++ b/flake.nix
@@ -3,14 +3,12 @@
 
   nixConfig = {
     extra-substituters = [
-      "https://blocksense.cachix.org"
-      "https://mcl-blockchain-packages.cachix.org"
-      "https://mcl-public-cache.cachix.org"
+      "https://cache.metacraft-labs.com/blocksense-public"
+      "https://cache.metacraft-labs.com/metacraft-public"
     ];
     extra-trusted-public-keys = [
-      "blocksense.cachix.org-1:BGg+LtKwTRIBw3BxCWEV//IO7v6+5CiJVSGzBOQUY/4="
-      "mcl-blockchain-packages.cachix.org-1:qoEiUyBgNXmgJTThjbjO//XA9/6tCmx/OohHHt9hWVY="
-      "mcl-public-cache.cachix.org-1:OcUzMeoSAwNEd3YCaEbNjLV5/Gd+U5VFxdN2WGHfpCI="
+      "blocksense-public:OOgTc0ye1FONCiVHMrbpScc/HP+lX3uoU0EfwzX6ypE="
+      "metacraft-public:UtS6PK+p0uZaJK3i/jD2DQOjTpddhQUQmNQDQih5N4Q="
     ];
   };
 


### PR DESCRIPTION
## Summary
- replace flake Cachix substituters with blocksense/metacraft Attic public caches
- remove Cachix Action setup from CI and configure Nix directly from Attic repo variables
- stop passing the legacy Blocksense infra Cachix token to the lock update workflow

## Validation
- nix flake metadata --accept-flake-config --no-write-lock-file
- yq parse over .github workflows
- targeted rg check for owned Cachix cache/action references